### PR TITLE
[feat] #5 카카오 소셜 로그인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.4.0'
-	id 'io.spring.dependency-management' version '1.1.6'
+	id 'org.springframework.boot' version '3.3.1'
+	id 'io.spring.dependency-management' version '1.1.5'
 }
 
 group = 'goodpartner'

--- a/src/main/java/goodpartner/be/domain/user/application/UserUsecase.java
+++ b/src/main/java/goodpartner/be/domain/user/application/UserUsecase.java
@@ -31,7 +31,6 @@ public class UserUsecase {
     public SocialLoginResponse login(SocialLoginRequest dto) {
         KakaoTokenResponse tokenResponse = kakaoAuthService.getKakaoToken(dto.authCode());
         KakaoUserInfoResponse userInfo = kakaoAuthService.getUserInfo(tokenResponse.access_token());
-        log.info("닉네임, {}", userInfo.kakao_account().profile().nickname());
 
         if (existUser(userInfo)) {
             return login(userInfo);
@@ -44,7 +43,10 @@ public class UserUsecase {
     }
 
     private SocialLoginResponse registerUser(KakaoUserInfoResponse userInfo) {
-        User user = User.of(userInfo.id(), userInfo.kakao_account().email());
+        String email = userInfo.kakao_account().email();
+        String nickName = userInfo.kakao_account().profile().nickname();
+
+        User user = User.of(userInfo.id(), email, nickName);
         userSaveService.saveUser(user);
 
         String accessToken = jwtProvider.generateAccessToken(userInfo.kakao_account().email());

--- a/src/main/java/goodpartner/be/domain/user/application/UserUsecase.java
+++ b/src/main/java/goodpartner/be/domain/user/application/UserUsecase.java
@@ -1,0 +1,64 @@
+package goodpartner.be.domain.user.application;
+
+import goodpartner.be.domain.user.application.dto.request.SocialLoginRequest;
+import goodpartner.be.domain.user.application.dto.response.SocialLoginResponse;
+import goodpartner.be.domain.user.entity.User;
+import goodpartner.be.domain.user.service.UserGetService;
+import goodpartner.be.domain.user.service.UserSaveService;
+import goodpartner.be.global.auth.jwt.JwtProvider;
+import goodpartner.be.global.auth.kakao.KakaoAuthService;
+import goodpartner.be.global.auth.kakao.dto.KakaoTokenResponse;
+import goodpartner.be.global.auth.kakao.dto.KakaoUserInfoResponse;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import static goodpartner.be.domain.user.entity.enums.LoginStatus.LOGIN;
+import static goodpartner.be.domain.user.entity.enums.LoginStatus.REGISTER;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserUsecase {
+
+    private final KakaoAuthService kakaoAuthService;
+    private final UserSaveService userSaveService;
+    private final UserGetService userGetService;
+    private final JwtProvider jwtProvider;
+
+    @Transactional
+    public SocialLoginResponse login(SocialLoginRequest dto) {
+        KakaoTokenResponse tokenResponse = kakaoAuthService.getKakaoToken(dto.authCode());
+        KakaoUserInfoResponse userInfo = kakaoAuthService.getUserInfo(tokenResponse.access_token());
+        log.info("닉네임, {}", userInfo.kakao_account().profile().nickname());
+
+        if (existUser(userInfo)) {
+            return login(userInfo);
+        }
+        return registerUser(userInfo);
+    }
+
+    public boolean existUser(KakaoUserInfoResponse userInfo) {
+        return userGetService.check(userInfo.id());
+    }
+
+    private SocialLoginResponse registerUser(KakaoUserInfoResponse userInfo) {
+        User user = User.of(userInfo.id(), userInfo.kakao_account().email());
+        userSaveService.saveUser(user);
+
+        String accessToken = jwtProvider.generateAccessToken(userInfo.kakao_account().email());
+        String refreshToken = jwtProvider.generateRefreshToken();
+
+        return SocialLoginResponse.of(user.getId(), REGISTER, accessToken, refreshToken);
+    }
+
+    private SocialLoginResponse login(KakaoUserInfoResponse userInfo) {
+        User user = userGetService.getUser(userInfo.id());
+
+        String accessToken = jwtProvider.generateAccessToken(userInfo.kakao_account().email());
+        String refreshToken = jwtProvider.generateRefreshToken();
+
+        return new SocialLoginResponse(user.getId(), LOGIN, accessToken, refreshToken);
+    }
+}

--- a/src/main/java/goodpartner/be/domain/user/application/dto/request/SocialLoginRequest.java
+++ b/src/main/java/goodpartner/be/domain/user/application/dto/request/SocialLoginRequest.java
@@ -1,0 +1,9 @@
+package goodpartner.be.domain.user.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record SocialLoginRequest(
+        @NotBlank String authCode
+
+) {
+}

--- a/src/main/java/goodpartner/be/domain/user/application/dto/response/SocialLoginResponse.java
+++ b/src/main/java/goodpartner/be/domain/user/application/dto/response/SocialLoginResponse.java
@@ -1,0 +1,16 @@
+package goodpartner.be.domain.user.application.dto.response;
+
+import goodpartner.be.domain.user.entity.enums.LoginStatus;
+
+import java.util.UUID;
+
+public record SocialLoginResponse(
+        UUID id,
+        LoginStatus status,
+        String accessToken,
+        String refreshToken
+) {
+    public static SocialLoginResponse of(UUID userId, LoginStatus status, String accessToken, String refreshToken) {
+        return new SocialLoginResponse(userId, status, accessToken, refreshToken);
+    }
+}

--- a/src/main/java/goodpartner/be/domain/user/application/exception/UserNotFoundException.java
+++ b/src/main/java/goodpartner/be/domain/user/application/exception/UserNotFoundException.java
@@ -1,0 +1,9 @@
+package goodpartner.be.domain.user.application.exception;
+
+import goodpartner.be.global.common.exception.BaseException;
+
+public class UserNotFoundException extends BaseException {
+    public UserNotFoundException() {
+        super(404, "사용자가 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/goodpartner/be/domain/user/controller/ResponseMessage.java
+++ b/src/main/java/goodpartner/be/domain/user/controller/ResponseMessage.java
@@ -1,0 +1,14 @@
+package goodpartner.be.domain.user.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseMessage {
+
+    SOCIAL_LOGIN_SUCCESS("소셜 로그인에 성공했습니다."),
+    SOCIAL_REGISTER_SUCCESS("소셜 회원가입에 성공했습니다.");
+
+    private final String message;
+}

--- a/src/main/java/goodpartner/be/domain/user/controller/UserController.java
+++ b/src/main/java/goodpartner/be/domain/user/controller/UserController.java
@@ -1,0 +1,36 @@
+package goodpartner.be.domain.user.controller;
+
+import goodpartner.be.domain.user.application.UserUsecase;
+import goodpartner.be.domain.user.application.dto.request.SocialLoginRequest;
+import goodpartner.be.domain.user.application.dto.response.SocialLoginResponse;
+import goodpartner.be.global.common.response.ResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static goodpartner.be.domain.user.controller.ResponseMessage.SOCIAL_LOGIN_SUCCESS;
+import static goodpartner.be.domain.user.controller.ResponseMessage.SOCIAL_REGISTER_SUCCESS;
+import static goodpartner.be.domain.user.entity.enums.LoginStatus.LOGIN;
+import static org.springframework.http.HttpStatus.OK;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users")
+public class UserController {
+
+    private final UserUsecase userUsecase;
+
+    @PostMapping("/social-login")
+    @Operation(summary = "카카오 소셜 로그인/회원가입 API")
+    public ResponseDto<SocialLoginResponse> login(@RequestBody @Valid SocialLoginRequest dto) {
+        SocialLoginResponse response = userUsecase.login(dto);
+        if (response.status() == LOGIN) {
+            return ResponseDto.response(OK.value(), SOCIAL_LOGIN_SUCCESS.getMessage(), response);
+        }
+        return ResponseDto.response(OK.value(), SOCIAL_REGISTER_SUCCESS.getMessage(), response);
+    }
+}

--- a/src/main/java/goodpartner/be/domain/user/entity/User.java
+++ b/src/main/java/goodpartner/be/domain/user/entity/User.java
@@ -26,10 +26,11 @@ public class User {
 
     private String tel;
 
-    public static User of(Long kakaoId, String email) {
+    public static User of(Long kakaoId, String email, String name) {
         return User.builder()
                 .kakaoId(kakaoId)
                 .email(email)
+                .name(name)
                 .build();
     }
 }

--- a/src/main/java/goodpartner/be/domain/user/entity/User.java
+++ b/src/main/java/goodpartner/be/domain/user/entity/User.java
@@ -1,0 +1,35 @@
+package goodpartner.be.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "user_id")
+    private UUID id;
+
+    private Long kakaoId;
+
+    private String name;
+
+    private String email;
+
+    private String tel;
+
+    public static User of(Long kakaoId, String email) {
+        return User.builder()
+                .kakaoId(kakaoId)
+                .email(email)
+                .build();
+    }
+}

--- a/src/main/java/goodpartner/be/domain/user/entity/enums/LoginStatus.java
+++ b/src/main/java/goodpartner/be/domain/user/entity/enums/LoginStatus.java
@@ -1,0 +1,5 @@
+package goodpartner.be.domain.user.entity.enums;
+
+public enum LoginStatus {
+    LOGIN, REGISTER
+}

--- a/src/main/java/goodpartner/be/domain/user/repository/UserRepository.java
+++ b/src/main/java/goodpartner/be/domain/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package goodpartner.be.domain.user.repository;
+
+import goodpartner.be.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByKakaoId(Long kakaoId);
+
+    boolean existsByKakaoId(Long kakaoId);
+}

--- a/src/main/java/goodpartner/be/domain/user/service/UserGetService.java
+++ b/src/main/java/goodpartner/be/domain/user/service/UserGetService.java
@@ -1,0 +1,23 @@
+package goodpartner.be.domain.user.service;
+
+import goodpartner.be.domain.user.application.exception.UserNotFoundException;
+import goodpartner.be.domain.user.entity.User;
+import goodpartner.be.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserGetService {
+
+    private final UserRepository userRepository;
+
+    public User getUser(Long kakaoId) {
+        return userRepository.findByKakaoId(kakaoId)
+                .orElseThrow(UserNotFoundException::new);
+    }
+
+    public boolean check(Long kakaoId) {
+        return userRepository.existsByKakaoId(kakaoId);
+    }
+}

--- a/src/main/java/goodpartner/be/domain/user/service/UserSaveService.java
+++ b/src/main/java/goodpartner/be/domain/user/service/UserSaveService.java
@@ -1,0 +1,17 @@
+package goodpartner.be.domain.user.service;
+
+import goodpartner.be.domain.user.entity.User;
+import goodpartner.be.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserSaveService {
+
+    private final UserRepository userRepository;
+
+    public void saveUser(User user) {
+        userRepository.save(user);
+    }
+}

--- a/src/main/java/goodpartner/be/global/auth/kakao/KakaoAuthService.java
+++ b/src/main/java/goodpartner/be/global/auth/kakao/KakaoAuthService.java
@@ -1,0 +1,54 @@
+package goodpartner.be.global.auth.kakao;
+
+import goodpartner.be.global.auth.kakao.dto.KakaoTokenResponse;
+import goodpartner.be.global.auth.kakao.dto.KakaoUserInfoResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+@Service
+@Slf4j
+public class KakaoAuthService {
+
+    @Value("${auth.kakao.client_id}")
+    private String kakaoClientId;
+    @Value("${auth.kakao.redirect_uri}")
+    private String redirectUri;
+    @Value("${auth.kakao.grant_type}")
+    private String grantType;
+    @Value("${auth.kakao.token_uri}")
+    private String tokenUri;
+    @Value("${auth.kakao.user_info_uri}")
+    private String userInfoUri;
+
+
+    private final RestClient restClient = RestClient.create();
+
+    public KakaoTokenResponse getKakaoToken(String authCode) {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", grantType);
+        body.add("client_id", kakaoClientId);
+        body.add("redirect_uri", redirectUri);
+        body.add("code", authCode);
+
+        return restClient.post()
+                .uri(tokenUri)
+                .body(body)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .retrieve()
+                .body(KakaoTokenResponse.class);
+    }
+
+    public KakaoUserInfoResponse getUserInfo(String accessToken) {
+        return restClient.get()
+                .uri(userInfoUri)
+                .header("Authorization", "Bearer " + accessToken)
+                .retrieve()
+                .body(KakaoUserInfoResponse.class);
+
+    }
+}

--- a/src/main/java/goodpartner/be/global/auth/kakao/dto/KakaoAccount.java
+++ b/src/main/java/goodpartner/be/global/auth/kakao/dto/KakaoAccount.java
@@ -1,0 +1,9 @@
+package goodpartner.be.global.auth.kakao.dto;
+
+public record KakaoAccount(
+        Boolean is_email_valid,
+        Boolean is_email_verified,
+        String email,
+        Profile profile
+) {
+}

--- a/src/main/java/goodpartner/be/global/auth/kakao/dto/KakaoTokenResponse.java
+++ b/src/main/java/goodpartner/be/global/auth/kakao/dto/KakaoTokenResponse.java
@@ -1,0 +1,10 @@
+package goodpartner.be.global.auth.kakao.dto;
+
+public record KakaoTokenResponse(
+        String token_type,
+        String access_token,
+        Integer expires_in,
+        String refresh_token,
+        Integer refresh_token_expires_in
+) {
+}

--- a/src/main/java/goodpartner/be/global/auth/kakao/dto/KakaoUserInfoResponse.java
+++ b/src/main/java/goodpartner/be/global/auth/kakao/dto/KakaoUserInfoResponse.java
@@ -1,0 +1,7 @@
+package goodpartner.be.global.auth.kakao.dto;
+
+public record KakaoUserInfoResponse(
+        Long id,
+        KakaoAccount kakao_account
+) {
+}

--- a/src/main/java/goodpartner/be/global/auth/kakao/dto/Profile.java
+++ b/src/main/java/goodpartner/be/global/auth/kakao/dto/Profile.java
@@ -1,0 +1,6 @@
+package goodpartner.be.global.auth.kakao.dto;
+
+public record Profile(
+        String nickname
+) {
+}

--- a/src/main/java/goodpartner/be/global/config/SecurityConfig.java
+++ b/src/main/java/goodpartner/be/global/config/SecurityConfig.java
@@ -50,7 +50,7 @@ public class SecurityConfig {
                         authorize ->
                                 authorize
                                         .requestMatchers("/v3/api-docs", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/swagger/**").permitAll()
-                                        .requestMatchers("/api/v1/users/login").permitAll()
+                                        .requestMatchers("/users/social-login").permitAll()
                                         .anyRequest().authenticated()
 
                 )


### PR DESCRIPTION
## PR 내용
- 카카오 소셜 로그인을 구현하였습니다
<br>

## PR 세부사항
- 카카오 소셜 로그인 구현 (email, nickname, id를 받아와 저장)
- 최초 요청시 회원가입 / 재 요청시 로그인으로 요청 분리
- 하지만 서비스 플로우에 회원정보 입력이 없기 때문에 사실상 동일합니다
- 스프링 최신버전이 스웨거와 호환이 되지 않아 다운했습니다
<br>

## 관련 스크린샷
- 회원가입
<img width="598" alt="image" src="https://github.com/user-attachments/assets/39194ab8-fef5-48fb-b93b-a06d00877928">

- 로그인
<img width="598" alt="image" src="https://github.com/user-attachments/assets/5a85ebcb-3302-4e82-bf3d-dad5095179aa">

<br>

## 주의사항
- 기존 controller - service - repository 사이에 usecase가 들어가게됩니다. 해당 클래스의 역할은 서비스 로직과 repository 간의 격리 + 순환참조를 방지 + 여러 서비스를 의존해 비즈니스 로직 작성 입니다.
- controller - usecase - service - repository의 계층을 가지게 됩니다. controller는 usecase를 의존하고, usecase는 여러 개의 service를 의존하는 방식으로 로직을 작성합니다. 자세한 로직은 다음 PR의 코드를 참고해주세요!
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. [feat] #10 기능 추가)
- [x] 변경 사항에 대한 테스트