### PR TITLE
[feat] #8 회원 정보 수정, 회원 정보 조회 api 구현

### DIFF
--- a/src/main/java/goodpartner/be/domain/user/application/dto/request/UserUpdateRequest.java
+++ b/src/main/java/goodpartner/be/domain/user/application/dto/request/UserUpdateRequest.java
@@ -1,0 +1,12 @@
+package goodpartner.be.domain.user.application.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record UserUpdateRequest(
+        @NotBlank String name,
+        @Email @NotNull String email,
+        @NotBlank String tel
+) {
+}

--- a/src/main/java/goodpartner/be/domain/user/application/dto/response/UserResponse.java
+++ b/src/main/java/goodpartner/be/domain/user/application/dto/response/UserResponse.java
@@ -1,0 +1,13 @@
+package goodpartner.be.domain.user.application.dto.response;
+
+import goodpartner.be.domain.user.entity.User;
+
+public record UserResponse(
+        String name,
+        String email,
+        String tel
+) {
+    public static UserResponse from(User user) {
+        return new UserResponse(user.getName(), user.getEmail(), user.getTel());
+    }
+}

--- a/src/main/java/goodpartner/be/domain/user/controller/ResponseMessage.java
+++ b/src/main/java/goodpartner/be/domain/user/controller/ResponseMessage.java
@@ -8,7 +8,10 @@ import lombok.Getter;
 public enum ResponseMessage {
 
     SOCIAL_LOGIN_SUCCESS("소셜 로그인에 성공했습니다."),
-    SOCIAL_REGISTER_SUCCESS("소셜 회원가입에 성공했습니다.");
+    SOCIAL_REGISTER_SUCCESS("소셜 회원가입에 성공했습니다."),
+    GET_MY_INFO("내 정보 조회에 성공했습니다."),
+    UPDATE_MY_INFO("내 정보 수정에 성공했습니다..");
+
 
     private final String message;
 }

--- a/src/main/java/goodpartner/be/domain/user/controller/UserController.java
+++ b/src/main/java/goodpartner/be/domain/user/controller/UserController.java
@@ -2,21 +2,22 @@ package goodpartner.be.domain.user.controller;
 
 import goodpartner.be.domain.user.application.UserUsecase;
 import goodpartner.be.domain.user.application.dto.request.SocialLoginRequest;
+import goodpartner.be.domain.user.application.dto.request.UserUpdateRequest;
 import goodpartner.be.domain.user.application.dto.response.SocialLoginResponse;
+import goodpartner.be.domain.user.application.dto.response.UserResponse;
 import goodpartner.be.global.common.response.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
-import static goodpartner.be.domain.user.controller.ResponseMessage.SOCIAL_LOGIN_SUCCESS;
-import static goodpartner.be.domain.user.controller.ResponseMessage.SOCIAL_REGISTER_SUCCESS;
+import static goodpartner.be.domain.user.controller.ResponseMessage.*;
 import static goodpartner.be.domain.user.entity.enums.LoginStatus.LOGIN;
 import static org.springframework.http.HttpStatus.OK;
 
+@Tag(name = "USER")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/users")
@@ -32,5 +33,19 @@ public class UserController {
             return ResponseDto.response(OK.value(), SOCIAL_LOGIN_SUCCESS.getMessage(), response);
         }
         return ResponseDto.response(OK.value(), SOCIAL_REGISTER_SUCCESS.getMessage(), response);
+    }
+
+    @GetMapping
+    @Operation(summary = "회원 정보 조회")
+    public ResponseDto<UserResponse> get(@AuthenticationPrincipal String userId) {
+        UserResponse response = userUsecase.getUser(userId);
+        return ResponseDto.response(OK.value(), GET_MY_INFO.getMessage(), response);
+    }
+
+    @PatchMapping
+    @Operation(summary = "회원 정보 수정")
+    public ResponseDto<String> update(@RequestBody @Valid UserUpdateRequest dto, @AuthenticationPrincipal String userId) {
+        userUsecase.update(dto, userId);
+        return ResponseDto.response(OK.value(), UPDATE_MY_INFO.getMessage());
     }
 }

--- a/src/main/java/goodpartner/be/domain/user/entity/User.java
+++ b/src/main/java/goodpartner/be/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package goodpartner.be.domain.user.entity;
 
+import goodpartner.be.domain.user.application.dto.request.UserUpdateRequest;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -32,5 +33,11 @@ public class User {
                 .email(email)
                 .name(name)
                 .build();
+    }
+
+    public void update(UserUpdateRequest dto) {
+        this.email = dto.email();
+        this.name = dto.name();
+        this.tel = dto.tel();
     }
 }

--- a/src/main/java/goodpartner/be/domain/user/repository/UserRepository.java
+++ b/src/main/java/goodpartner/be/domain/user/repository/UserRepository.java
@@ -4,8 +4,9 @@ import goodpartner.be.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import java.util.UUID;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, UUID> {
     Optional<User> findByKakaoId(Long kakaoId);
 
     boolean existsByKakaoId(Long kakaoId);

--- a/src/main/java/goodpartner/be/domain/user/service/UserGetService.java
+++ b/src/main/java/goodpartner/be/domain/user/service/UserGetService.java
@@ -6,6 +6,8 @@ import goodpartner.be.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.UUID;
+
 @Service
 @RequiredArgsConstructor
 public class UserGetService {
@@ -14,6 +16,11 @@ public class UserGetService {
 
     public User getUser(Long kakaoId) {
         return userRepository.findByKakaoId(kakaoId)
+                .orElseThrow(UserNotFoundException::new);
+    }
+
+    public User getUser(UUID userId) {
+        return userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
     }
 

--- a/src/main/java/goodpartner/be/domain/user/service/UserUpdateService.java
+++ b/src/main/java/goodpartner/be/domain/user/service/UserUpdateService.java
@@ -1,0 +1,13 @@
+package goodpartner.be.domain.user.service;
+
+import goodpartner.be.domain.user.application.dto.request.UserUpdateRequest;
+import goodpartner.be.domain.user.entity.User;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserUpdateService {
+
+    public void updateUser(User user, UserUpdateRequest dto) {
+        user.update(dto);
+    }
+}

--- a/src/main/java/goodpartner/be/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/goodpartner/be/global/auth/jwt/JwtProvider.java
@@ -32,11 +32,11 @@ public class JwtProvider {
         this.key = new SecretKeySpec(jwtKey.getBytes(), SignatureAlgorithm.HS256.getJcaName());
     }
 
-    public String generateAccessToken(String email) {
+    public String generateAccessToken(UUID userId) {
         final Date now = new Date();
         final Date expiration = new Date(now.getTime() + accessTokenExpirationTime);
         return Jwts.builder()
-                .setSubject(email)
+                .setSubject(userId.toString())
                 .setIssuedAt(now)
                 .setExpiration(expiration)
                 .signWith(key)
@@ -80,8 +80,8 @@ public class JwtProvider {
 
     public Authentication getAuthentication(String token) {
         Claims claims = parseToken(token);
-        String email = claims.getSubject();
+        String userId = claims.getSubject();
 
-        return new UsernamePasswordAuthenticationToken(email, null, Collections.emptyList());
+        return new UsernamePasswordAuthenticationToken(userId, null, Collections.emptyList());
     }
 }


### PR DESCRIPTION
## PR 내용
- 회원 정보 수정, 회원 정보 조회 api를 구현했습니다.

<br>

## PR 세부사항
- 정보 조회, 수정은 각 서비스에서 진행하도록 구현했습니다. 따라서 전반적인 로직은 UserUsecase에서 진행합니다.
- UserUsecase는 유저 도메인과 관련된 서비스들을 의존하고, 서비스 간에는 의존을 하지 않습니다.
<br>

## 관련 스크린샷
-  내정보 조회
<img width="451" alt="스크린샷 2024-12-04 오전 10 41 40" src="https://github.com/user-attachments/assets/bf6063a4-b0a1-48db-b246-81ce6363b63d">

- 내정보 수정
<img width="621" alt="image" src="https://github.com/user-attachments/assets/e28557c7-949a-44de-bb1d-4459cd7c4522">

<br>

## 주의사항
- MSA로 구현을 하기 때문에 Chat과 User는 의존관계를 맺지 않습니다. 구현시 Chat 엔티티에 userId를 포함하되, User DB에 접근하거나, User 객체를 가지지 않고, JWT 토큰에서 userId를 추출해서 함께 저장하도록 구현해주셔야합니다
<br>

## 체크 리스트

- [x] 리뷰어 설정
- [x] Assignee 설정
- [x] Label 설정
- [x] 제목 양식 맞췄나요? (ex. [feat] #10 기능 추가)
- [x] 변경 사항에 대한 테스트